### PR TITLE
fix: add undefined formatString fallback

### DIFF
--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -38,8 +38,8 @@ var LocalizedStrings = function () {
 
         /**
          * Get the best match based on the language passed and the available languages
-         * @param {*} language 
-         * @param {*} props 
+         * @param {*} language
+         * @param {*} props
          */
         value: function _getBestMatchingLanguage(language, props) {
             //If an object with the passed language key exists return it
@@ -54,7 +54,7 @@ var LocalizedStrings = function () {
         /**
          * Constructor used to provide the strings objects in various language and the optional callback to get
          * the interface language
-         * @param {*} props - the strings object 
+         * @param {*} props - the strings object
          * @param {*} getInterfaceLanguageCallback - the optional method to use to get the InterfaceLanguage
          */
 
@@ -74,7 +74,7 @@ var LocalizedStrings = function () {
 
     /**
      * Set the strings objects based on the parameter passed in the constructor
-     * @param {*} props 
+     * @param {*} props
      */
 
 
@@ -99,7 +99,7 @@ var LocalizedStrings = function () {
         /**
          * Can be used from ouside the class to force a particular language
          * indipendently from the interface one
-         * @param {*} language 
+         * @param {*} language
          */
 
     }, {
@@ -132,8 +132,8 @@ var LocalizedStrings = function () {
 
         /**
          * Load fallback values for missing translations
-         * @param {*} defaultStrings 
-         * @param {*} strings 
+         * @param {*} defaultStrings
+         * @param {*} strings
          */
 
     }, {
@@ -203,7 +203,7 @@ var LocalizedStrings = function () {
                 valuesForPlaceholders[_key - 1] = arguments[_key];
             }
 
-            return str.split(placeholderRegex).filter(function (textPart) {
+            return (str || '').split(placeholderRegex).filter(function (textPart) {
                 return !!textPart;
             }).map(function (textPart, index) {
                 if (textPart.match(placeholderRegex)) {

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -149,7 +149,7 @@ describe('Main Library Functions', function () {
         boiledEgg:"Uovo bollito",
       }
     });
-    
+
     strings.setContent(Object.assign({},strings.getContent(),
       {
         en:{
@@ -158,9 +158,9 @@ describe('Main Library Functions', function () {
           }
       }));
 
-     expect(strings.how).toEqual('How do you want your egg todajsie?'); 
+     expect(strings.how).toEqual('How do you want your egg todajsie?');
      strings.setLanguage('it');
-     expect(strings.how).toEqual('Come vuoi il tuo uovo oggi?'); 
+     expect(strings.how).toEqual('Come vuoi il tuo uovo oggi?');
   });
 
   it('Handles named tokens as part of the format string', () => {
@@ -175,9 +175,13 @@ describe('Main Library Functions', function () {
 
   it('Handles falsy values', () => {
     //falsy: "{0} {1} {2} {3} {4} {5}"
-    console.log(`#${strings.formatString(strings.falsy, 0, false, '', null, undefined, NaN)}#`)
     expect(strings.formatString(strings.falsy, 0, false, '', null, undefined, NaN))
       .toEqual([0, false, '', null, undefined, NaN].join(' '));
+  });
+
+  it('Handles empty values', () => {
+    expect(strings.formatString(strings.thisKeyDoesNotExist, { thisReplacement: 'doesNotExist'}))
+      .toEqual('');
   });
 
 });
@@ -191,7 +195,7 @@ describe('use the default getInterfaceLanguageMethod', () => {
       language:"italian"
     }});
     it('Use the default method that returns en-US', () => {
-      expect (strings.language).toBe("english");
+      expect(strings.language).toBe("english");
     });
 });
 

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -22,8 +22,8 @@ const placeholderRegex = /(\{[\d|\w]+\})/;
 export default class LocalizedStrings {
     /**
      * Get the best match based on the language passed and the available languages
-     * @param {*} language 
-     * @param {*} props 
+     * @param {*} language
+     * @param {*} props
      */
     _getBestMatchingLanguage(language, props) {
         //If an object with the passed language key exists return it
@@ -38,7 +38,7 @@ export default class LocalizedStrings {
     /**
      * Constructor used to provide the strings objects in various language and the optional callback to get
      * the interface language
-     * @param {*} props - the strings object 
+     * @param {*} props - the strings object
      * @param {*} getInterfaceLanguageCallback - the optional method to use to get the InterfaceLanguage
      */
     constructor(props, getInterfaceLanguageCallback) {
@@ -53,7 +53,7 @@ export default class LocalizedStrings {
 
     /**
      * Set the strings objects based on the parameter passed in the constructor
-     * @param {*} props 
+     * @param {*} props
      */
     setContent(props){
         this._defaultLanguage = Object.keys(props)[0];
@@ -74,7 +74,7 @@ export default class LocalizedStrings {
     /**
      * Can be used from ouside the class to force a particular language
      * indipendently from the interface one
-     * @param {*} language 
+     * @param {*} language
      */
     setLanguage(language) {
         //Check if exists a translation for the current language or if the default
@@ -104,8 +104,8 @@ export default class LocalizedStrings {
 
     /**
      * Load fallback values for missing translations
-     * @param {*} defaultStrings 
-     * @param {*} strings 
+     * @param {*} defaultStrings
+     * @param {*} strings
      */
     _fallbackValues(defaultStrings, strings) {
         for (let key in defaultStrings) {
@@ -138,7 +138,7 @@ export default class LocalizedStrings {
 
     /**
      * Return an array containing the available languages passed as props in the constructor
-     */ 
+     */
     getAvailableLanguages() {
         if (!this._availableLanguages) {
             this._availableLanguages = [];
@@ -156,7 +156,7 @@ export default class LocalizedStrings {
     //eg. 1: strings.formatString(strings.question, strings.bread, strings.butter)
     //eg. 2: strings.formatString(strings.question, { bread: strings.bread, butter: strings.butter })
     formatString(str, ...valuesForPlaceholders) {
-        return str
+        return (str || '')
             .split(placeholderRegex)
             .filter(textPart => !!textPart)
             .map((textPart, index) => {
@@ -193,7 +193,7 @@ export default class LocalizedStrings {
 
      /**
       * The current props (locale object)
-      */ 
+      */
      getContent() {
         return this._props;
     }


### PR DESCRIPTION
Add a fallback (empty string) value when the specified key is not found when calling `formatString()`.

closes #3