### PR TITLE
Allow for language strings to contain empty strings

### DIFF
--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -140,7 +140,7 @@ var LocalizedStrings = function () {
         key: '_fallbackValues',
         value: function _fallbackValues(defaultStrings, strings) {
             for (var key in defaultStrings) {
-                if (defaultStrings.hasOwnProperty(key) && !strings[key]) {
+                if (defaultStrings.hasOwnProperty(key) && !strings[key] && strings[key] !== '') {
                     strings[key] = defaultStrings[key];
                     console.log('\uD83D\uDEA7 \uD83D\uDC77 key \'' + key + '\' not found in localizedStrings for language ' + this._language + ' \uD83D\uDEA7');
                 } else {

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -20,7 +20,8 @@ describe('Main Library Functions', function () {
         },
         missing:"missing value",
         currentDate: "The current date is {month} {day}, {year}!",
-        falsy: "{0} {1} {2} {3} {4} {5}"
+        falsy: "{0} {1} {2} {3} {4} {5}",
+        empty: ""
       },
       it: {
         language: "italian",
@@ -34,7 +35,8 @@ describe('Main Library Functions', function () {
         },
         formattedValue:"Vorrei un po' di {0} e {1}, o solo {0}",
         currentDate: "La data corrente è {month} {day}, {year}!",
-        falsy: "{0} {1} {2} {3} {4} {5}"
+        falsy: "{0} {1} {2} {3} {4} {5}",
+        empty: ""
       }
     });
   });
@@ -182,6 +184,10 @@ describe('Main Library Functions', function () {
   it('Handles empty values', () => {
     expect(strings.formatString(strings.thisKeyDoesNotExist, { thisReplacement: 'doesNotExist'}))
       .toEqual('');
+  });
+
+  it('Handles empty strings', () => {
+    expect(strings.empty).toEqual('')
   });
 
 });

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -109,7 +109,7 @@ export default class LocalizedStrings {
      */
     _fallbackValues(defaultStrings, strings) {
         for (let key in defaultStrings) {
-            if (defaultStrings.hasOwnProperty(key) && !strings[key]) {
+            if (defaultStrings.hasOwnProperty(key) && !strings[key] && strings[key] !== '') {
                 strings[key] = defaultStrings[key];
                 console.log(`🚧 👷 key '${key}' not found in localizedStrings for language ${this._language} 🚧`);
             } else {


### PR DESCRIPTION
This PR would get rid of the console message "..key not found in localizedStrings..." when the translation exists but is a empty string.  I'm using the library "react-localization" which depends on this library so if this PR would get accepted I would like a new release of react-localization if that's possible :-) .

Thanks.