### PR TITLE
Features/psuedo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,10 @@
 module.exports = {
-  extends: 'airbnb-base',
+  extends: "airbnb-base",
   rules: {
-    'max-len': 'off',
-    'class-methods-use-this': 'off',
-    'no-underscore-dangle': 'off',
-    'no-console': 'off',
-  },
+    "max-len": "off",
+    "class-methods-use-this": "off",
+    "no-underscore-dangle": "off",
+    "no-console": "off",
+    "linebreak-style": "off"
+  }
 };

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ In the class that you want to localize require the library and define the string
 ```js
 \\ES6 module syntax
 import LocalizedStrings from 'localized-strings';
+\\CommonJS module syntax
+const LocalizedStrings = require('LocalizedStrings').default;
 
 let strings = new LocalizedStrings({
  en:{
@@ -164,10 +166,8 @@ this.strings = new LocalizedStrings(
 
 ```js
   en:{
-    bread:"bread",
-    butter:"butter",
     question:"I'd like {0} and {1}, or just {0}",
-    questionWithReferences:"I'd like $ref{bread} and $ref{butter}, or just $ref{bread}",
+    questionWithReferences:"I'd like $ref{fridge.bread} and $ref{fridge.butter}, or just $ref{fridge.bread}",
     ...
     login: 'login',
     onlyForMembers: 'You have to {0} in order to use our app',
@@ -175,11 +175,20 @@ this.strings = new LocalizedStrings(
     iAmText: 'I am {0} text',
     ...
     january: 'January',
-    currentDate: 'The current date is {month} {day}, {year}!'
+    currentDate: 'The current date is {month} {day}, {year}!',
+    fridge: {
+      milk: 'milk',
+      eggs: 'eggs',
+      bread: 'bread',
+      butter: 'butter'
+    }
   }
   ...
   // Will output: I'd like bread and butter, or just bread
-  strings.formatString(strings.question, strings.bread, strings.butter)
+  strings.formatString(strings.question, strings.fridge.bread, strings.fridge.butter)
+
+  // Will output: I'd like bread and butter, or just bread
+  strings.formatString(strings.question, strings.fridge)
 
   // Will output: I'd like bread and butter, or just bread
   strings.formatString(strings.questionWithReferences)
@@ -191,6 +200,9 @@ this.strings = new LocalizedStrings(
     day: 12,
     year: 2018
   })
+
+  // Possible to use formatString with dot-notation, this is same as .getString and will not crash the application if the key isn't found.
+  strings.formatString('fridge.missing.subnode')
 ```
 
 **Beware: do not define a string key as formatString!**

--- a/README.md
+++ b/README.md
@@ -27,27 +27,28 @@ import LocalizedStrings from 'localized-strings';
 const LocalizedStrings = require('LocalizedStrings').default;
 
 let strings = new LocalizedStrings({
- en:{
-   how:"How do you want your egg today?",
-   boiledEgg:"Boiled egg",
-   softBoiledEgg:"Soft-boiled egg",
-   choice:"How to choose the egg",
-   fridge: {
-     egg: "Egg",
-     milk: "Milk",
-   }
- },
- it: {
-   how:"Come vuoi il tuo uovo oggi?",
-   boiledEgg:"Uovo sodo",
-   softBoiledEgg:"Uovo alla coque",
-   choice:"Come scegliere l'uovo",
-   fridge: {
-     egg: "Uovo",
-     milk: "Latte",
-   }
- }
-});
+  en:{
+    how:"How do you want your egg today?",
+    boiledEgg:"Boiled egg",
+    softBoiledEgg:"Soft-boiled egg",
+    choice:"How to choose the egg",
+    fridge: {
+      egg: "Egg",
+      milk: "Milk",
+    }
+  },
+  it: {
+    how:"Come vuoi il tuo uovo oggi?",
+    boiledEgg:"Uovo sodo",
+    softBoiledEgg:"Uovo alla coque",
+    choice:"Come scegliere l'uovo",
+    fridge: {
+      egg: "Uovo",
+      milk: "Latte",
+    }
+  }},
+    {/* options */}
+);
 ```
 
 Then use the `strings` object literal directly in the render method accessing the key of the localized string.
@@ -129,7 +130,9 @@ let strings = new LocalizedStrings(
       choice: "Come scegliere l'uovo"
     }
   },
-  getCustomInterfaceLanguage
+  {
+    customLanguageInterface: getCustomInterfaceLanguage
+  }
 );
 ```
 
@@ -141,22 +144,61 @@ This is how you can use the library in a [Nativescript](https://www.nativescript
 const platform = require("platform");
 this.strings = new LocalizedStrings(
   {
-    it: {
-      score: "Punti",
-      time: "Tempo"
-    },
     en: {
       score: "Score",
       time: "Time"
     }
   },
-  () => {
-    return platform.device.language;
+  {
+    customLanguageInterface: () => {
+      return platform.device.language;
+    }
   }
 );
 ```
 
+## Psuedo Helper
+
+Sometimes you have already a lot of text string in your project and starts to implement a language component. Using Psuedo during this phase can help to speed up finding what is done and not.
+
+In constructor you can enable
+
+```js
+pseudo: true;
+```
+
+This will turn a string as 'hello you' to '[qxjE2gx qtBy]'. This will help you quickly to see what strings are not using the localized-strings component. The randomized characters are wrapped in [ ]. These are to help you view the bounds of the string, so if they arent visible it might be outside the viewing area.
+
+### Multiple Languages
+
+If you are about to implement multiple languages you can enable
+
+```js
+pseudoMultipleLanguages: true;
+```
+
+This will make all strings about 40% longer.
+
 ## API
+
+- constructor(languageObject,options)
+
+```js
+  options
+  {
+    // custom function that returns device language
+    // @see 'Custom getInterfaceLanguage method' for more info
+    customLanguageInterface: () => return 'it-IT'
+    // Output issues finding strings and references
+    logsEnabled: true
+    // Helper for finding string that is implemented
+    // @see Pseudo Helper for more info
+    pseudo: false
+    // Helper for preparing multiple langauges
+    // @see Pseudo Helper for more info
+    pseudoMultipleLanguages: false
+  }
+```
 
 - setLanguage(languageCode) - to force manually a particular language
 - getLanguage() - to get the current displayed language
@@ -168,12 +210,6 @@ this.strings = new LocalizedStrings(
   en:{
     question:"I'd like {0} and {1}, or just {0}",
     questionWithReferences:"I'd like $ref{fridge.bread} and $ref{fridge.butter}, or just $ref{fridge.bread}",
-    ...
-    login: 'login',
-    onlyForMembers: 'You have to {0} in order to use our app',
-    bold: 'bold',
-    iAmText: 'I am {0} text',
-    ...
     january: 'January',
     currentDate: 'The current date is {month} {day}, {year}!',
     fridge: {

--- a/example.js
+++ b/example.js
@@ -1,0 +1,51 @@
+const LocalizedStrings = require('./lib/LocalizedStrings').default;
+
+const strings = new LocalizedStrings({
+  en: {
+    question: "I'd like {0} and {1}, or just {0}",
+    questionWithObject: "I'd like {bread} and {eggs}, or just {bread}",
+    questionWithReferences:
+      "I'd like $ref{fridge.bread} and $ref{fridge.butter}, or just $ref{fridge.bread}",
+    login: 'login',
+    onlyForMembers: 'You have to {0} in order to use our app',
+    bold: 'bold',
+    iAmText: 'I am {0} text',
+    january: 'January',
+    currentDate: 'The current date is {month} {day}, {year}!',
+    fridge: {
+      milk: 'milk',
+      eggs: 'eggs',
+      bread: 'bread',
+      butter: 'butter',
+    },
+  },
+});
+
+// Will output: I'd like bread and butter, or just bread
+console.log('Input each value');
+console.log(
+  '   ',
+  strings.formatString(
+    strings.question,
+    strings.fridge.bread,
+    strings.fridge.butter,
+  ),
+);
+
+// Will output: I'd like bread and butter, or just bread
+console.log('Input object');
+console.log(
+  '   ',
+  strings.formatString(strings.questionWithObject, strings.fridge),
+);
+
+// Will output: I'd like bread and butter, or just bread
+console.log('Input references from string');
+console.log('   ', strings.formatString(strings.questionWithReferences));
+
+// Possible to use formatString with dot-notation, this is same as .getString and will not crash the application if the key isn't found.
+console.log('Input string that doesnt exists');
+console.log('   ', strings.formatString('fridge.missing'));
+
+console.log('Input object that doesnt exists');
+console.log('   ', strings.formatString(strings.fridge.missing.more));

--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -1,66 +1,80 @@
-declare module 'localized-strings' {
-    type Formatted = number | string;
-    type FormatObject<U extends Formatted> = { [key: string]: U };
-    
-    export interface GlobalStrings<T> {
-      [language: string]: T;
-    }
-    
-    type GetInterfaceLanguageCallback = () => string;
+declare module "localized-strings" {
+  type Formatted = number | string;
+  type FormatObject<U extends Formatted> = { [key: string]: U };
 
-    export interface LocalizedStringsMethods {
-        /**
-         * Can be used from ouside the class to force a particular language
-         * indipendently from the interface one
-         * @param language 
-         */
-        setLanguage(language: string): void;
-
-        /**
-         *  The current language displayed (could differ from the interface language
-         *  if it has been forced manually and a matching translation has been found)
-         */
-        getLanguage(): string;
-
-        /**
-         * The current interface language (could differ from the language displayed)
-         */
-        getInterfaceLanguage(): string;
-
-        /**
-         * Format the passed string replacing the numbered placeholders
-         * i.e. I'd like some {0} and {1}, or just {0}
-         * Use example:
-         *   strings.formatString(strings.question, strings.bread, strings.butter)
-         */
-        formatString<T extends Formatted>(str: string, ...values: Array<T | FormatObject<T>>): Array<string | T> | string;
-
-        /**
-         * Return an array containing the available languages passed as props in the constructor
-         */
-        getAvailableLanguages(): string[];
-
-        /**
-         * Return a string with the passed key in a different language
-         * @param key 
-         * @param language 
-         */
-        getString(key: string, language: string): string;
-
-        /**
-         * Replace the NamedLocalization object without reinstantiating the object
-         * @param props 
-         */
-        setContent(props: any): void;
-    }
-
-    export type LocalizedStrings<T> = LocalizedStringsMethods & T;
-  
-    
-    interface LocalizedStringsFactory {
-        new <T>(props: GlobalStrings<T>, getInterfaceLanguage?:GetInterfaceLanguageCallback): LocalizedStrings<T>;
-    }
-  
-    const LocalizedStrings: LocalizedStringsFactory;
-    export default LocalizedStrings;
+  export interface GlobalStrings<T> {
+    [language: string]: T;
   }
+
+  type GetInterfaceLanguageCallback = () => string;
+
+  export interface LocalizedStringsMethods {
+    /**
+     * Can be used from ouside the class to force a particular language
+     * indipendently from the interface one
+     * @param language
+     */
+    setLanguage(language: string): void;
+
+    /**
+     *  The current language displayed (could differ from the interface language
+     *  if it has been forced manually and a matching translation has been found)
+     */
+    getLanguage(): string;
+
+    /**
+     * The current interface language (could differ from the language displayed)
+     */
+    getInterfaceLanguage(): string;
+
+    /**
+     * Format the passed string replacing the numbered placeholders
+     * i.e. I'd like some {0} and {1}, or just {0}
+     * Use example:
+     *   strings.formatString(strings.question, strings.bread, strings.butter)
+     */
+    formatString<T extends Formatted>(
+      str: string,
+      ...values: Array<T | FormatObject<T>>
+    ): Array<string | T> | string;
+
+    /**
+     * Return an array containing the available languages passed as props in the constructor
+     */
+    getAvailableLanguages(): string[];
+
+    /**
+     * Return a string with the passed key in a different language
+     * @param key
+     * @param language
+     * @param omitWarning
+     */
+    getString(
+      key: string,
+      language: string,
+      omitWarning: boolean = false
+    ): string;
+
+    /**
+     * Replace the NamedLocalization object without reinstantiating the object
+     * @param props
+     */
+    setContent(props: any): void;
+  }
+
+  export type LocalizedStrings<T> = LocalizedStringsMethods & T;
+
+  interface Options {
+    customLanguageInterface?: GetInterfaceLanguageCallback;
+    logsEnabled?: boolean;
+    pseudo?: boolean;
+    pseudoMultipleLanguages?: boolean;
+  }
+
+  interface LocalizedStringsFactory {
+    new <T>(props: GlobalStrings<T>, oprions?: Options): LocalizedStrings<T>;
+  }
+
+  const LocalizedStrings: LocalizedStringsFactory;
+  export default LocalizedStrings;
+}

--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -47,11 +47,7 @@ declare module "localized-strings" {
      * @param language
      * @param omitWarning
      */
-    getString(
-      key: string,
-      language: string,
-      omitWarning: boolean = false
-    ): string;
+    getString(key: string, language: string, omitWarning: boolean): string;
 
     /**
      * Replace the NamedLocalization object without reinstantiating the object

--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -6,8 +6,6 @@ declare module "localized-strings" {
     [language: string]: T;
   }
 
-  type GetInterfaceLanguageCallback = () => string;
-
   export interface LocalizedStringsMethods {
     /**
      * Can be used from ouside the class to force a particular language
@@ -64,6 +62,8 @@ declare module "localized-strings" {
 
   export type LocalizedStrings<T> = LocalizedStringsMethods & T;
 
+  type GetInterfaceLanguageCallback = () => string;
+
   interface Options {
     customLanguageInterface?: GetInterfaceLanguageCallback;
     logsEnabled?: boolean;
@@ -72,7 +72,7 @@ declare module "localized-strings" {
   }
 
   interface LocalizedStringsFactory {
-    new <T>(props: GlobalStrings<T>, oprions?: Options): LocalizedStrings<T>;
+    new <T>(props: GlobalStrings<T>, options?: Options): LocalizedStrings<T>;
   }
 
   const LocalizedStrings: LocalizedStringsFactory;

--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -111,6 +111,10 @@ var LocalizedStrings = function () {
         if (_typeof(obj[property]) === 'object') {
           _this2._pseudoAllValues(obj[property]);
         } else if (typeof obj[property] === 'string') {
+          if (obj[property].indexOf('[') === 0 && obj[property].lastIndexOf(']') === obj[property].length - 1) {
+            // already psuedo fixed
+            return;
+          }
           // @TODO must be a way to get regex to find all replaceble strings except our replacement variables
           var strArr = obj[property].split(' ');
           for (var i = 0; i < strArr.length; i += 1) {

--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -4,9 +4,11 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -42,16 +44,21 @@ var LocalizedStrings = function () {
    * Constructor used to provide the strings objects in various language and the optional callback to get
    * the interface language
    * @param {*} props - the strings object
-   * @param {*} getInterfaceLanguageCallback - the optional method to use to get the InterfaceLanguage
+   * @param {Function} options.customLanguageInterface - the optional method to use to get the InterfaceLanguage
+   * @param {Boolean} options.pseudo - convert all strings to pseudo, helpful when implementing
+   * @param {Boolean} options.pseudoMultipleLanguages - add 40% to pseudo, helps with translations in the future
+   * @param {Boolean} options.logsEnabled - Enable/Disable console.log outputs (default=true)
    */
-  function LocalizedStrings(props, getInterfaceLanguageCallback) {
+  function LocalizedStrings(props, options) {
     _classCallCheck(this, LocalizedStrings);
 
-    if (getInterfaceLanguageCallback) {
-      this._interfaceLanguage = getInterfaceLanguageCallback();
-    } else {
-      this._interfaceLanguage = utils.getInterfaceLanguage();
-    }
+    this._opts = _extends({}, {
+      customLanguageInterface: utils.getInterfaceLanguage,
+      pseudo: false,
+      pseudoMultipleLanguages: false,
+      logsEnabled: true
+    }, options);
+    this._interfaceLanguage = this._opts.customLanguageInterface();
     this._language = this._interfaceLanguage;
     this.setContent(props);
   }
@@ -84,6 +91,44 @@ var LocalizedStrings = function () {
       });
       // Set language to its default value (the interface)
       this.setLanguage(this._interfaceLanguage);
+      // Developermode with pseudo
+      if (this._opts.pseudo) {
+        this._pseudoAllValues(this._props);
+      }
+    }
+
+    /**
+     * Replace all strings to pseudo value
+     * @param {Object} obj - Loopable object
+     */
+
+  }, {
+    key: '_pseudoAllValues',
+    value: function _pseudoAllValues(obj) {
+      var _this2 = this;
+
+      Object.keys(obj).forEach(function (property) {
+        if (_typeof(obj[property]) === 'object') {
+          _this2._pseudoAllValues(obj[property]);
+        } else if (typeof obj[property] === 'string') {
+          // @TODO must be a way to get regex to find all replaceble strings except our replacement variables
+          var strArr = obj[property].split(' ');
+          for (var i = 0; i < strArr.length; i += 1) {
+            if (strArr[i].match(placeholderReplaceRegex)) {
+              // we want to keep this string, includes specials
+            } else if (strArr[i].match(placeholderReferenceRegex)) {
+              // we want to keep this string, includes specials
+            } else {
+              var len = strArr[i].length;
+              if (_this2._opts.pseudoMultipleLanguages) {
+                len = parseInt(len * 1.4, 10); // add length with 40%
+              }
+              strArr[i] = utils.randomPseudo(len);
+            }
+          }
+          obj[property] = '[' + strArr.join(' ') + ']'; // eslint-disable-line no-param-reassign
+        }
+      });
     }
 
     /**
@@ -95,7 +140,7 @@ var LocalizedStrings = function () {
   }, {
     key: 'setLanguage',
     value: function setLanguage(language) {
-      var _this2 = this;
+      var _this3 = this;
 
       // Check if exists a translation for the current language or if the default
       // should be used
@@ -110,7 +155,7 @@ var LocalizedStrings = function () {
         }
         var localizedStrings = _extends({}, this._props[this._language]);
         Object.keys(localizedStrings).forEach(function (key) {
-          _this2[key] = localizedStrings[key];
+          _this3[key] = localizedStrings[key];
         });
         // Now add any string missing from the translation but existing in the default language
         if (defaultLanguage !== this._language) {
@@ -129,15 +174,17 @@ var LocalizedStrings = function () {
   }, {
     key: '_fallbackValues',
     value: function _fallbackValues(defaultStrings, strings) {
-      var _this3 = this;
+      var _this4 = this;
 
       Object.keys(defaultStrings).forEach(function (key) {
         if (Object.prototype.hasOwnProperty.call(defaultStrings, key) && !strings[key] && strings[key] !== '') {
           strings[key] = defaultStrings[key]; // eslint-disable-line no-param-reassign
-          console.log('\uD83D\uDEA7 \uD83D\uDC77 key \'' + key + '\' not found in localizedStrings for language ' + _this3._language + ' \uD83D\uDEA7');
+          if (_this4._opts.logsEnabled) {
+            console.log('\uD83D\uDEA7 \uD83D\uDC77 key \'' + key + '\' not found in localizedStrings for language ' + _this4._language + ' \uD83D\uDEA7');
+          }
         } else if (typeof strings[key] !== 'string') {
           // It's an object
-          _this3._fallbackValues(defaultStrings[key], strings[key]);
+          _this4._fallbackValues(defaultStrings[key], strings[key]);
         }
       });
     }
@@ -170,12 +217,12 @@ var LocalizedStrings = function () {
   }, {
     key: 'getAvailableLanguages',
     value: function getAvailableLanguages() {
-      var _this4 = this;
+      var _this5 = this;
 
       if (!this._availableLanguages) {
         this._availableLanguages = [];
         Object.keys(this._props).forEach(function (key) {
-          _this4._availableLanguages.push(key);
+          _this5._availableLanguages.push(key);
         });
       }
       return this._availableLanguages;
@@ -184,14 +231,16 @@ var LocalizedStrings = function () {
     // Format the passed string replacing the numbered or tokenized placeholders
     // eg. 1: I'd like some {0} and {1}, or just {0}
     // eg. 2: I'd like some {bread} and {butter}, or just {bread}
+    // eg. 3: I'd like some $ref{bread} and $ref{butter}, or just $ref{bread}
     // Use example:
     // eg. 1: strings.formatString(strings.question, strings.bread, strings.butter)
     // eg. 2: strings.formatString(strings.question, { bread: strings.bread, butter: strings.butter })
+    // eg. 3: strings.formatString(strings.question)
 
   }, {
     key: 'formatString',
     value: function formatString(str) {
-      var _this5 = this;
+      var _this6 = this;
 
       for (var _len = arguments.length, valuesForPlaceholders = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
         valuesForPlaceholders[_key - 1] = arguments[_key];
@@ -206,9 +255,11 @@ var LocalizedStrings = function () {
       }).map(function (textPart) {
         if (textPart.match(placeholderReferenceRegex)) {
           var matchedKey = textPart.slice(5, -1);
-          var referenceValue = _this5.getString(matchedKey);
+          var referenceValue = _this6.getString(matchedKey);
           if (referenceValue) return referenceValue;
-          console.log('No Localization ref found for \'' + textPart + '\' in string \'' + str + '\'');
+          if (_this6._opts.logsEnabled) {
+            console.log('No Localization ref found for \'' + textPart + '\' in string \'' + str + '\'');
+          }
           // lets print it another way so next replacer doesn't find it
           return '$ref(id:' + matchedKey + ')';
         }
@@ -256,7 +307,7 @@ var LocalizedStrings = function () {
         }
         return current;
       } catch (ex) {
-        if (!omitWarning) {
+        if (!omitWarning && this._opts.logsEnabled) {
           console.log('No localization found for key \'' + key + '\' and language \'' + language + '\', failed on ' + ex.message);
         }
       }

--- a/lib/LocalizedStrings.js
+++ b/lib/LocalizedStrings.js
@@ -197,7 +197,11 @@ var LocalizedStrings = function () {
         valuesForPlaceholders[_key - 1] = arguments[_key];
       }
 
-      var ref = (str || '').split(placeholderReferenceRegex).filter(function (textPart) {
+      var input = str || '';
+      if (typeof input === 'string') {
+        input = this.getString(str, null, true) || input;
+      }
+      var ref = input.split(placeholderReferenceRegex).filter(function (textPart) {
         return !!textPart;
       }).map(function (textPart) {
         if (textPart.match(placeholderReferenceRegex)) {
@@ -216,7 +220,6 @@ var LocalizedStrings = function () {
         if (textPart.match(placeholderReplaceRegex)) {
           var matchedKey = textPart.slice(1, -1);
           var valueForPlaceholder = valuesForPlaceholders[matchedKey];
-
           // If no value found, check if working with an object instead
           if (valueForPlaceholder === undefined) {
             var valueFromObjectPlaceholder = valuesForPlaceholders[0][matchedKey];
@@ -240,6 +243,8 @@ var LocalizedStrings = function () {
   }, {
     key: 'getString',
     value: function getString(key, language) {
+      var omitWarning = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+
       try {
         var current = this._props[language || this._language];
         var paths = key.split('.');
@@ -251,7 +256,9 @@ var LocalizedStrings = function () {
         }
         return current;
       } catch (ex) {
-        console.log('No localization found for key \'' + key + '\' and language \'' + language + '\', failed on ' + ex.message);
+        if (!omitWarning) {
+          console.log('No localization found for key \'' + key + '\' and language \'' + language + '\', failed on ' + ex.message);
+        }
       }
       return null;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 exports.getInterfaceLanguage = getInterfaceLanguage;
 exports.getBestMatchingLanguage = getBestMatchingLanguage;
 exports.validateTranslationKeys = validateTranslationKeys;
+exports.randomPseudo = randomPseudo;
 /**
  * Return the current interface language
  * If the navigator object is defined it returns the current navigator language
@@ -62,4 +63,16 @@ function validateTranslationKeys(translationKeys) {
       throw new Error(key + ' cannot be used as a key. It is a reserved word.');
     }
   });
+}
+
+/**
+ * Get a random pseudo string back after specified a length
+ * @param {Number} len - How many characters to get back
+ */
+function randomPseudo(len) {
+  var text = '';
+  var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (var i = 0; i < len; i += 1) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }return text;
 }

--- a/spec/LocalizedStrings.spec.js
+++ b/spec/LocalizedStrings.spec.js
@@ -8,42 +8,45 @@ describe('Main Library Functions', () => {
   let strings;
 
   beforeEach(() => {
-    strings = new LocalizedStrings({
-      en: {
-        language: 'english',
-        how: 'How do you want your egg today?',
-        boiledEgg: 'Boiled egg',
-        softBoiledEgg: 'Soft-boiled egg',
-        choice: 'How to choose the egg',
-        formattedValue: "I'd like some {0} and {1}, or just {0}",
-        ratings: {
-          excellent: 'excellent',
-          good: 'good',
-          missingComplex: 'missing value',
+    strings = new LocalizedStrings(
+      {
+        en: {
+          language: 'english',
+          how: 'How do you want your egg today?',
+          boiledEgg: 'Boiled egg',
+          softBoiledEgg: 'Soft-boiled egg',
+          choice: 'How to choose the egg',
+          formattedValue: "I'd like some {0} and {1}, or just {0}",
+          ratings: {
+            excellent: 'excellent',
+            good: 'good',
+            missingComplex: 'missing value',
+          },
+          missing: 'missing value',
+          currentDate: 'The current date is {month} {day}, {year}!',
+          falsy: '{0} {1} {2} {3} {4} {5}',
+          empty: '',
+          reference: '$ref{ratings.excellent}',
+          referenceAdvanced: '$ref{falsy}',
         },
-        missing: 'missing value',
-        currentDate: 'The current date is {month} {day}, {year}!',
-        falsy: '{0} {1} {2} {3} {4} {5}',
-        empty: '',
-        reference: '$ref{ratings.excellent}',
-        referenceAdvanced: '$ref{falsy}',
-      },
-      it: {
-        language: 'italian',
-        how: 'Come vuoi il tuo uovo oggi?',
-        boiledEgg: 'Uovo sodo',
-        softBoiledEgg: 'Uovo alla coque',
-        choice: "Come scegliere l'uovo",
-        ratings: {
-          excellent: 'eccellente',
-          good: 'buono',
+        it: {
+          language: 'italian',
+          how: 'Come vuoi il tuo uovo oggi?',
+          boiledEgg: 'Uovo sodo',
+          softBoiledEgg: 'Uovo alla coque',
+          choice: "Come scegliere l'uovo",
+          ratings: {
+            excellent: 'eccellente',
+            good: 'buono',
+          },
+          formattedValue: "Vorrei un po' di {0} e {1}, o solo {0}",
+          currentDate: 'La data corrente è {month} {day}, {year}!',
+          falsy: '{0} {1} {2} {3} {4} {5}',
+          empty: '',
         },
-        formattedValue: "Vorrei un po' di {0} e {1}, o solo {0}",
-        currentDate: 'La data corrente è {month} {day}, {year}!',
-        falsy: '{0} {1} {2} {3} {4} {5}',
-        empty: '',
       },
-    });
+      { logsEnabled: false },
+    );
   });
 
   it('Set default language to en', () => {
@@ -224,14 +227,17 @@ describe('Main Library Functions', () => {
 });
 
 describe('use the default getInterfaceLanguageMethod', () => {
-  const strings = new LocalizedStrings({
-    en: {
-      language: 'english',
+  const strings = new LocalizedStrings(
+    {
+      en: {
+        language: 'english',
+      },
+      it: {
+        language: 'italian',
+      },
     },
-    it: {
-      language: 'italian',
-    },
-  });
+    { logsEnabled: false },
+  );
   it('Use the default method that returns en-US', () => {
     expect(strings.language).toBe('english');
   });
@@ -247,12 +253,26 @@ describe('use a custom getInterfaceLanguageMethod', () => {
         language: 'italian',
       },
     },
-    () => 'it-IT',
+    { customLanguageInterface: () => 'it-IT', logsEnabled: false },
   );
   it('Use the custom method that returns it_IT', () => {
     expect(strings.language).toBe('italian');
   });
   it('Use the custom interface methods when checking the getInterfaceLanguage', () => {
     expect(strings.getInterfaceLanguage()).toBe('it-IT');
+  });
+});
+
+describe('use psuedo characters', () => {
+  const strings = new LocalizedStrings(
+    {
+      en: {
+        language: 'english',
+      },
+    },
+    { pseudo: true, logsEnabled: false },
+  );
+  it('Psuedo changed value', () => {
+    expect(strings.formatString('language')).not.toBe('english');
   });
 });

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -78,6 +78,13 @@ export default class LocalizedStrings {
       if (typeof obj[property] === 'object') {
         this._pseudoAllValues(obj[property]);
       } else if (typeof obj[property] === 'string') {
+        if (
+          obj[property].indexOf('[') === 0
+          && obj[property].lastIndexOf(']') === obj[property].length - 1
+        ) {
+          // already psuedo fixed
+          return;
+        }
         // @TODO must be a way to get regex to find all replaceble strings except our replacement variables
         const strArr = obj[property].split(' ');
         for (let i = 0; i < strArr.length; i += 1) {
@@ -223,7 +230,7 @@ export default class LocalizedStrings {
           let valueForPlaceholder = valuesForPlaceholders[matchedKey];
           // If no value found, check if working with an object instead
           if (valueForPlaceholder === undefined) {
-            const valueFromObjectPlaceholder = valuesForPlaceholders[0][matchedKey];
+            const valueFromObjectPlaceholder =              valuesForPlaceholders[0][matchedKey];
             if (valueFromObjectPlaceholder !== undefined) {
               valueForPlaceholder = valueFromObjectPlaceholder;
             } else {

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -145,7 +145,11 @@ export default class LocalizedStrings {
   // eg. 1: strings.formatString(strings.question, strings.bread, strings.butter)
   // eg. 2: strings.formatString(strings.question, { bread: strings.bread, butter: strings.butter })
   formatString(str, ...valuesForPlaceholders) {
-    const ref = (str || '')
+    let input = str || '';
+    if (typeof input === 'string') {
+      input = this.getString(str, null, true) || input;
+    }
+    const ref = input
       .split(placeholderReferenceRegex)
       .filter(textPart => !!textPart)
       .map((textPart) => {
@@ -169,10 +173,9 @@ export default class LocalizedStrings {
         if (textPart.match(placeholderReplaceRegex)) {
           const matchedKey = textPart.slice(1, -1);
           let valueForPlaceholder = valuesForPlaceholders[matchedKey];
-
           // If no value found, check if working with an object instead
           if (valueForPlaceholder === undefined) {
-            const valueFromObjectPlaceholder = valuesForPlaceholders[0][matchedKey];
+            const valueFromObjectPlaceholder =              valuesForPlaceholders[0][matchedKey];
             if (valueFromObjectPlaceholder !== undefined) {
               valueForPlaceholder = valueFromObjectPlaceholder;
             } else {
@@ -190,7 +193,7 @@ export default class LocalizedStrings {
 
   // Return a string with the passed key in a different language or defalt if not set
   // We allow deep . notation for finding strings
-  getString(key, language) {
+  getString(key, language, omitWarning = false) {
     try {
       let current = this._props[language || this._language];
       const paths = key.split('.');
@@ -202,11 +205,13 @@ export default class LocalizedStrings {
       }
       return current;
     } catch (ex) {
-      console.log(
-        `No localization found for key '${key}' and language '${language}', failed on ${
-          ex.message
-        }`,
-      );
+      if (!omitWarning) {
+        console.log(
+          `No localization found for key '${key}' and language '${language}', failed on ${
+            ex.message
+          }`,
+        );
+      }
     }
     return null;
   }

--- a/src/LocalizedStrings.js
+++ b/src/LocalizedStrings.js
@@ -23,14 +23,23 @@ export default class LocalizedStrings {
    * Constructor used to provide the strings objects in various language and the optional callback to get
    * the interface language
    * @param {*} props - the strings object
-   * @param {*} getInterfaceLanguageCallback - the optional method to use to get the InterfaceLanguage
+   * @param {Function} options.customLanguageInterface - the optional method to use to get the InterfaceLanguage
+   * @param {Boolean} options.pseudo - convert all strings to pseudo, helpful when implementing
+   * @param {Boolean} options.pseudoMultipleLanguages - add 40% to pseudo, helps with translations in the future
+   * @param {Boolean} options.logsEnabled - Enable/Disable console.log outputs (default=true)
    */
-  constructor(props, getInterfaceLanguageCallback) {
-    if (getInterfaceLanguageCallback) {
-      this._interfaceLanguage = getInterfaceLanguageCallback();
-    } else {
-      this._interfaceLanguage = utils.getInterfaceLanguage();
-    }
+  constructor(props, options) {
+    this._opts = Object.assign(
+      {},
+      {
+        customLanguageInterface: utils.getInterfaceLanguage,
+        pseudo: false,
+        pseudoMultipleLanguages: false,
+        logsEnabled: true,
+      },
+      options,
+    );
+    this._interfaceLanguage = this._opts.customLanguageInterface();
     this._language = this._interfaceLanguage;
     this.setContent(props);
   }
@@ -54,6 +63,39 @@ export default class LocalizedStrings {
     });
     // Set language to its default value (the interface)
     this.setLanguage(this._interfaceLanguage);
+    // Developermode with pseudo
+    if (this._opts.pseudo) {
+      this._pseudoAllValues(this._props);
+    }
+  }
+
+  /**
+   * Replace all strings to pseudo value
+   * @param {Object} obj - Loopable object
+   */
+  _pseudoAllValues(obj) {
+    Object.keys(obj).forEach((property) => {
+      if (typeof obj[property] === 'object') {
+        this._pseudoAllValues(obj[property]);
+      } else if (typeof obj[property] === 'string') {
+        // @TODO must be a way to get regex to find all replaceble strings except our replacement variables
+        const strArr = obj[property].split(' ');
+        for (let i = 0; i < strArr.length; i += 1) {
+          if (strArr[i].match(placeholderReplaceRegex)) {
+            // we want to keep this string, includes specials
+          } else if (strArr[i].match(placeholderReferenceRegex)) {
+            // we want to keep this string, includes specials
+          } else {
+            let len = strArr[i].length;
+            if (this._opts.pseudoMultipleLanguages) {
+              len = parseInt(len * 1.4, 10); // add length with 40%
+            }
+            strArr[i] = utils.randomPseudo(len);
+          }
+        }
+        obj[property] = `[${strArr.join(' ')}]`; // eslint-disable-line no-param-reassign
+      }
+    });
   }
 
   /**
@@ -98,11 +140,13 @@ export default class LocalizedStrings {
         && strings[key] !== ''
       ) {
         strings[key] = defaultStrings[key]; // eslint-disable-line no-param-reassign
-        console.log(
-          `🚧 👷 key '${key}' not found in localizedStrings for language ${
-            this._language
-          } 🚧`,
-        );
+        if (this._opts.logsEnabled) {
+          console.log(
+            `🚧 👷 key '${key}' not found in localizedStrings for language ${
+              this._language
+            } 🚧`,
+          );
+        }
       } else if (typeof strings[key] !== 'string') {
         // It's an object
         this._fallbackValues(defaultStrings[key], strings[key]);
@@ -141,9 +185,11 @@ export default class LocalizedStrings {
   // Format the passed string replacing the numbered or tokenized placeholders
   // eg. 1: I'd like some {0} and {1}, or just {0}
   // eg. 2: I'd like some {bread} and {butter}, or just {bread}
+  // eg. 3: I'd like some $ref{bread} and $ref{butter}, or just $ref{bread}
   // Use example:
   // eg. 1: strings.formatString(strings.question, strings.bread, strings.butter)
   // eg. 2: strings.formatString(strings.question, { bread: strings.bread, butter: strings.butter })
+  // eg. 3: strings.formatString(strings.question)
   formatString(str, ...valuesForPlaceholders) {
     let input = str || '';
     if (typeof input === 'string') {
@@ -157,9 +203,11 @@ export default class LocalizedStrings {
           const matchedKey = textPart.slice(5, -1);
           const referenceValue = this.getString(matchedKey);
           if (referenceValue) return referenceValue;
-          console.log(
-            `No Localization ref found for '${textPart}' in string '${str}'`,
-          );
+          if (this._opts.logsEnabled) {
+            console.log(
+              `No Localization ref found for '${textPart}' in string '${str}'`,
+            );
+          }
           // lets print it another way so next replacer doesn't find it
           return `$ref(id:${matchedKey})`;
         }
@@ -175,7 +223,7 @@ export default class LocalizedStrings {
           let valueForPlaceholder = valuesForPlaceholders[matchedKey];
           // If no value found, check if working with an object instead
           if (valueForPlaceholder === undefined) {
-            const valueFromObjectPlaceholder =              valuesForPlaceholders[0][matchedKey];
+            const valueFromObjectPlaceholder = valuesForPlaceholders[0][matchedKey];
             if (valueFromObjectPlaceholder !== undefined) {
               valueForPlaceholder = valueFromObjectPlaceholder;
             } else {
@@ -205,7 +253,7 @@ export default class LocalizedStrings {
       }
       return current;
     } catch (ex) {
-      if (!omitWarning) {
+      if (!omitWarning && this._opts.logsEnabled) {
         console.log(
           `No localization found for key '${key}' and language '${language}', failed on ${
             ex.message

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,3 +61,14 @@ export function validateTranslationKeys(translationKeys) {
     }
   });
 }
+
+/**
+ * Get a random pseudo string back after specified a length
+ * @param {Number} len - How many characters to get back
+ */
+export function randomPseudo(len) {
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < len; i += 1) text += possible.charAt(Math.floor(Math.random() * possible.length));
+  return text;
+}


### PR DESCRIPTION
Add the possibility to use psuedo characters when implementing. Sometimes localization comes later in the development process and knowing what is moved to localized-strings can be hard. To not start adding strange characters to each string to keep track. Developer can use 'fake strings' instead.

This adds the possibility to allow the plugin to automatically create fake strings.
This pull request will change constructor to take an 'options' variable
```js
{
   psuedo: true|false // will translate all strings
   pseudoMultipleLanguages: true|false // will add 40% to string length
}
```

**Before staring to move strings**
![psuedo-before](https://user-images.githubusercontent.com/4478361/46208588-80665400-c32b-11e8-94ea-903374cd6c0a.PNG)

**After moved a couple of strings**
Easy to see what's implemented
![psuedo-after](https://user-images.githubusercontent.com/4478361/46208589-80665400-c32b-11e8-8617-1e96c79b9d5f.PNG)

**from updated readme**

## Psuedo Helper

Sometimes you have already a lot of text string in your project and starts to implement a language component. Using Psuedo during this phase can help to speed up finding what is done and not.

In constructor you can enable

```js
pseudo: true;
```

This will turn a string as 'hello you' to '[qxjE2gx qtBy]'. This will help you quickly to see what strings are not using the localized-strings component. The randomized characters are wrapped in [ ]. These are to help you view the bounds of the string, so if they arent visible it might be outside the viewing area.

### Multiple Languages

If you are about to implement multiple languages you can enable

```js
pseudoMultipleLanguages: true;
```

This will make all strings about 40% longer.