### PR TITLE
Update LocalizedStrings.d.ts

### DIFF
--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -34,7 +34,7 @@ declare module "localized-strings" {
     formatString<T extends Formatted>(
       str: string,
       ...values: Array<T | FormatObject<T>>
-    ): Array<string | T> | string;
+    ): string;
 
     /**
      * Return an array containing the available languages passed as props in the constructor


### PR DESCRIPTION
As far as I can tell the return type of formatString is just a string. At the moment it returns a weird type if you pass it an object with named parameters...